### PR TITLE
PHR-13269 - Smaller bugfixes

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,6 +43,15 @@ import {RouteReuseStrategy} from "@angular/router";
 import { BackToTopComponent } from './elements/element-selection-tab/back-to-top/back-to-top.component';
 import {PreviewComponent, SafeHtmlPipe} from './preview/preview.component';
 import {FormsModule} from "@angular/forms";
+import { DatePickerElementComponent } from './elements/element-selection-tab/date-picker/date-picker-element.component';
+import { DatePickerElementDialogComponent } from './elements/element-selection-tab/date-picker/date-picker-dialog/date-picker-element-dialog.component';
+import { SeparatorElementComponent } from './elements/element-selection-tab/separator-element/separator-element.component';
+import { ImageElementComponent } from './elements/element-selection-tab/image-element/image-element.component';
+import {NgOptimizedImage} from "@angular/common";
+import { ImageElementDialogComponent } from './elements/element-selection-tab/image-element/image-element-dialog/image-element-dialog.component';
+import { VideoElementComponent } from './elements/element-selection-tab/video-element/video-element.component';
+import { VideoElementDialogComponent } from './elements/element-selection-tab/video-element/video-element-dialog/video-element-dialog.component';
+import { GoToSaveCpElementComponent } from './elements/element-selection-tab/go-to-save-cp-element/go-to-save-cp-element.component';
 
 @NgModule({
   declarations: [
@@ -65,7 +74,15 @@ import {FormsModule} from "@angular/forms";
     GenerateComponent,
     BackToTopComponent,
     PreviewComponent,
-    SafeHtmlPipe
+    SafeHtmlPipe,
+    DatePickerElementComponent,
+    DatePickerElementDialogComponent,
+    SeparatorElementComponent,
+    ImageElementComponent,
+    ImageElementDialogComponent,
+    VideoElementComponent,
+    VideoElementDialogComponent,
+    GoToSaveCpElementComponent
   ],
   imports: [
     BrowserModule,
@@ -74,6 +91,7 @@ import {FormsModule} from "@angular/forms";
     FormsModule,
     MatInputModule,
     AppRoutingModule,
+    NgOptimizedImage,
   ],
   providers: [ElementType, Service, {provide: RouteReuseStrategy, useClass: AppReuseStrategy}, SafeHtmlPipe, GenerateComponent],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -75,7 +75,7 @@ import {FormsModule} from "@angular/forms";
     MatInputModule,
     AppRoutingModule,
   ],
-  providers: [ElementType, Service, {provide: RouteReuseStrategy, useClass: AppReuseStrategy}, SafeHtmlPipe],
+  providers: [ElementType, Service, {provide: RouteReuseStrategy, useClass: AppReuseStrategy}, SafeHtmlPipe, GenerateComponent],
   bootstrap: [AppComponent]
 })
 export class AppModule {

--- a/src/app/elements/element-selection-tab/back-to-top/back-to-top.component.html
+++ b/src/app/elements/element-selection-tab/back-to-top/back-to-top.component.html
@@ -1,3 +1,5 @@
 <button class="button-back-to-top" title="Back to Top">Back to Top</button>
-<button (click)="elementComponent.moveComponentDown(position, name)">MOVE DOWN</button>
-<button (click)="elementComponent.moveComponentUp(position, name)">MOVE UP</button>
+<button (click)="removeElement()">REMOVE</button>
+<button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+<button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
+

--- a/src/app/elements/element-selection-tab/back-to-top/back-to-top.component.ts
+++ b/src/app/elements/element-selection-tab/back-to-top/back-to-top.component.ts
@@ -23,7 +23,7 @@ export class BackToTopComponent implements OnInit{
   }
 
   generateHtml() {
-    return ' <button href="#top" class="cp_button-back-to-top" title="Back to Top" >Back to Top</button>\n';
+    return '     <button href="#top" class="cp_button-back-to-top" title="Back to Top" >Back To Top</button>';
   }
 
   constructor(public elementComponent: ElementsComponent) {}

--- a/src/app/elements/element-selection-tab/checkbox-element/checkbox-element-dialog/checkbox-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/checkbox-element/checkbox-element-dialog/checkbox-element-dialog.component.html
@@ -10,6 +10,6 @@
 </div>
 <div mat-dialog-actions>
     <button (click)="populatingCheckBoxValues()" [mat-dialog-close]="[label, checkBoxValues]">Save</button>
-    <button [mat-dialog-close]="">Cancel</button>
+    <button [mat-dialog-close]="[]">Cancel</button>
 </div>
 

--- a/src/app/elements/element-selection-tab/checkbox-element/checkbox-element-dialog/checkbox-element-dialog.component.ts
+++ b/src/app/elements/element-selection-tab/checkbox-element/checkbox-element-dialog/checkbox-element-dialog.component.ts
@@ -29,7 +29,6 @@ export class CheckboxElementDialogComponent {
   }
 
   removeCheckbox(indexOfTheElement: number){
-    console.log(indexOfTheElement)
     if (this.checkBoxValues.length > 1) {
       this.checkBoxValues.splice(indexOfTheElement,1);
       this.bufferCheckBoxValues.splice(indexOfTheElement, 1);

--- a/src/app/elements/element-selection-tab/checkbox-element/checkbox-element.component.html
+++ b/src/app/elements/element-selection-tab/checkbox-element/checkbox-element.component.html
@@ -11,7 +11,7 @@
   </div>
   <button (click)="openDialog()">EDIT</button>
   <button (click)="removeElement()">REMOVE</button>
-  <button (click)="elementComponent.moveComponentDown(position, name)">MOVE DOWN</button>
-  <button (click)="elementComponent.moveComponentUp(position, name)">MOVE UP</button>
+  <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+  <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
 </div>
 

--- a/src/app/elements/element-selection-tab/checkbox-element/checkbox-element.component.ts
+++ b/src/app/elements/element-selection-tab/checkbox-element/checkbox-element.component.ts
@@ -24,34 +24,33 @@ export class CheckboxElementComponent implements ElementType {
     this.label = 'LABEL';}
 
   generateHtml() {
-    return ' <div class="row cp_checkbox-element" style="margin-top: 15px;">\n' +
-      '  <div class="col-sm-6 cp_input-group">\n' +
-      '   <p class="cp_label">\n' + this.label +
-      '   </p>\n' +
-      '  </div>\n' +
-      '   <div class="col-sm-6" style="margin-top: 15px;">\n' +
-      '       <div class="form-check col-xs-12 pull-left input-group">\n' + this.generateCheckboxes() +
+    return '     <div class="row cp_checkbox-element" style="margin-top: 15px;">\n' +
+      '       <p class="cp_checkbox-element-label">' + this.label + '</p>\n' +
+      '       <div class=cp_checkbox-element-wraper" style="margin-top: 15px;">\n' +
+      '         <div class="cp_checkbox-options">\n' + this.generateCheckboxes() +
+      '         </div>\n' +
       '       </div>\n' +
-      '   </div>\n' +
-      '  </div>\n';
+      '     </div>';
   }
 
   openDialog(): void {
     if (!this.elementComponent.isDialogOpen) {
-      this.elementComponent.changeDialogOpenSate();
+      this.elementComponent.changeDialogState();
       const dialogRef = this.dialog.open(CheckboxElementDialogComponent, {
         data: {label: this.label, checkBoxValues: this.checkBoxValues},
       });
 
       dialogRef.afterClosed().subscribe(result => {
-        this.elementComponent.changeDialogOpenSate();
-        if (result[0] !== '') {
-          this.label = result[0];
-          this.htmlValue = this.generateHtml();
-          this.updateHtml.emit({
-            label: this.label,
-          })
-        }
+        this.elementComponent.changeDialogState();
+        if (result.length != 0){
+            if (result[0] !== '') {
+              this.label = result[0];
+              this.htmlValue = this.generateHtml();
+              this.updateHtml.emit({
+                label: this.label,
+              })
+            }
+          }
       });
     }
   }
@@ -59,7 +58,7 @@ export class CheckboxElementComponent implements ElementType {
   generateCheckboxes() {
     let options = '';
     for (let i = 0; i < this.checkBoxValues.length; i++) {
-      options += '    <div><input class="form-check-input form-control" type="checkbox" value="' + this.checkBoxValues[i] + ' required"><label class="cp_label col-xs-10 pull-right">' + this.checkBoxValues[i] + '</label></div>\n';
+      options += '           <div><input class="cp_checkbox-option" type="checkbox" value="' + this.checkBoxValues[i] + '"><label class="cp_label col-xs-10 pull-right">' + this.checkBoxValues[i] + '</label></div>\n';
     }
     return options;
   }

--- a/src/app/elements/element-selection-tab/date-picker/date-picker-dialog/date-picker-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/date-picker/date-picker-dialog/date-picker-element-dialog.component.html
@@ -1,0 +1,11 @@
+<div><h1 mat-dialog-title>Edit Input Field</h1>
+    <label>Label</label>
+    <input matInput [(ngModel)]="label" value=""><br>
+    <label>Help Text</label>
+    <input matInput [(ngModel)]="helpText" value="">
+    <div mat-dialog-actions>
+        <button [mat-dialog-close]="[label, helpText]">Save</button>
+        <button [mat-dialog-close]="[]">Cancel</button>
+    </div>
+</div>
+

--- a/src/app/elements/element-selection-tab/date-picker/date-picker-dialog/date-picker-element-dialog.component.ts
+++ b/src/app/elements/element-selection-tab/date-picker/date-picker-dialog/date-picker-element-dialog.component.ts
@@ -1,0 +1,19 @@
+import {Component, Inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
+import {DialogData} from "../../input-element/input-element-dialog/input-element-dialog.component";
+
+@Component({
+  selector: 'app-date-picker-dialog',
+  templateUrl: './date-picker-element-dialog.component.html',
+  styleUrls: ['./date-picker-element-dialog.component.css']
+})
+export class DatePickerElementDialogComponent {
+  public label: string;
+  public helpText: string;
+
+  constructor(public dialogRef: MatDialogRef<DatePickerElementDialogComponent>, @Inject(MAT_DIALOG_DATA) public data: DialogData) {
+    this.label = data.label;
+    this.helpText = data.helpText;
+  }
+
+}

--- a/src/app/elements/element-selection-tab/date-picker/date-picker-element.component.css
+++ b/src/app/elements/element-selection-tab/date-picker/date-picker-element.component.css
@@ -1,0 +1,7 @@
+.row {
+    margin-left: 20px;
+    margin-right: 20px;
+}
+button {
+    margin-right: 5px;
+}

--- a/src/app/elements/element-selection-tab/date-picker/date-picker-element.component.html
+++ b/src/app/elements/element-selection-tab/date-picker/date-picker-element.component.html
@@ -1,0 +1,13 @@
+<div class="row cp_date-picker" style="margin-top: 15px;">
+    <div class="col-sm-6 input-group">
+        <label class="cp_date-picker_label">{{label}}</label>
+    </div>
+    <div class="col-sm-6 input-group" style="margin-top: 15px;">
+        <input type="date" class="p_date-picker_input" placeholder="dd/mm/yyyy"/><br>
+        <span class="cp_date-picker-help-text">{{helpText}}</span>
+    </div>
+    <button (click)="openDialog()">EDIT</button>
+    <button (click)="removeElement()">REMOVE</button>
+    <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+    <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
+</div>

--- a/src/app/elements/element-selection-tab/date-picker/date-picker-element.component.ts
+++ b/src/app/elements/element-selection-tab/date-picker/date-picker-element.component.ts
@@ -1,0 +1,73 @@
+import {Component, EventEmitter, Input, Output, ViewChild, ViewContainerRef} from '@angular/core';
+import {ElementType} from "../element-selection-tab.component";
+import {MatDialog} from "@angular/material/dialog";
+import {ElementsComponent} from "../../elements.component";
+import {InputElementDialogComponent} from "../input-element/input-element-dialog/input-element-dialog.component";
+import {DatePickerElementDialogComponent} from "./date-picker-dialog/date-picker-element-dialog.component";
+
+@Component({
+  selector: 'app-date-picker',
+  templateUrl: './date-picker-element.component.html',
+  styleUrls: ['./date-picker-element.component.css']
+})
+export class DatePickerElementComponent implements ElementType {
+  @Input() name: string = '';
+  @Input() position: number;
+
+  @Output() moveUpElement = new EventEmitter<any>();
+  @Output() removedElement = new EventEmitter<any>();
+  @Output() updateHtml = new EventEmitter<any>();
+  @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef;
+
+  helpText: string = 'HELP TEXT';
+  label: string = 'LABEL';
+  htmlValue = this.generateHtml();
+
+  constructor(public dialog: MatDialog, public elementComponent: ElementsComponent) {
+  }
+
+  generateHtml() { return '      <div class="row cp_date-picker" style="margin-top: 15px;">\n' +
+    '         <div class="cp_date-picker-label-container">\n' +
+    '             <label class="cp_date-picker-label">' + this.label + '</label>\n' +
+    '         </div>\n' +
+    '         <div class="cp_date-picker-input-container" style="margin-top: 15px;">\n' +
+    '             <input type="date" class="cp_date-picker_input" placeholder="dd/mm/yyyy"/><br>\n' +
+    '             <span class="cp_date-picker-help-text">' + this.helpText + '</span>\n' +
+    '         </div>\n' +
+    '      </div>';
+  }
+
+  openDialog(): void {
+    if (!this.elementComponent.isDialogOpen) {
+      this.elementComponent.changeDialogState();
+      const dialogRef = this.dialog.open(DatePickerElementDialogComponent, {
+        data: {label: this.label, helpText: this.helpText},
+      });
+
+      dialogRef.afterClosed().subscribe(result => {
+        this.elementComponent.changeDialogState();
+        if (result.length != 0){
+          if (result[0] !== this.label) {
+            this.label = result[0];
+          }
+          if (result[2] !== '') {
+            this.helpText = result[1];
+          }
+        }
+
+        this.htmlValue = this.generateHtml();
+        this.updateHtml.emit({
+          label: this.label,
+          helpText: this.helpText
+        })
+      });
+    }
+  }
+
+  removeElement() {
+    this.removedElement.emit({
+      name: this.name,
+    })
+  }
+
+}

--- a/src/app/elements/element-selection-tab/element-selection-tab.component.html
+++ b/src/app/elements/element-selection-tab/element-selection-tab.component.html
@@ -8,13 +8,28 @@
   <div class="add-element" (click)="createComponent(selectType)"><label>Select</label>
     <button>+</button>
   </div>
-  <div class="add-element" (click)="createComponent(radioType)"><label>Radio buttons</label>
+  <div class="add-element" (click)="createComponent(radioType)"><label>Radio Buttons</label>
     <button>+</button>
   </div>
   <div class="add-element" (click)="createComponent(checkType)"><label>Checkboxes</label>
     <button>+</button>
   </div>
-  <div class="add-element" (click)="createComponent(backToTopType)"><label>Back to top button</label>
+  <div class="add-element" (click)="createComponent(backToTopType)"><label>Back To Top Button</label>
+    <button>+</button>
+  </div>
+  <div class="add-element" (click)="createComponent(datePickerType)"><label>Set Date</label>
+    <button>+</button>
+  </div>
+  <div class="add-element" (click)="createComponent(separatorType)"><label>Separator</label>
+    <button>+</button>
+  </div>
+  <div class="add-element" (click)="createComponent(imageType)"><label>Image</label>
+    <button>+</button>
+  </div>
+  <div class="add-element" (click)="createComponent(videoType)"><label>Video</label>
+    <button>+</button>
+  </div>
+  <div class="add-element" (click)="createComponent(goToSaveCPType)"><label>Go To Save Care Plan Button</label>
     <button>+</button>
   </div>
 </div>

--- a/src/app/elements/element-selection-tab/element-selection-tab.component.ts
+++ b/src/app/elements/element-selection-tab/element-selection-tab.component.ts
@@ -15,6 +15,11 @@ export class ElementSelectionTabComponent {
   radioType: string;
   checkType: string;
   backToTopType: string;
+  datePickerType: string;
+  separatorType: string;
+  imageType: string;
+  videoType: string;
+  goToSaveCPType: string;
 
   constructor(public elementComponent: ElementsComponent) {
     this.textType = 'textElementComponent';
@@ -23,6 +28,11 @@ export class ElementSelectionTabComponent {
     this.radioType = 'radioElementComponent';
     this.checkType = 'checkElementComponent';
     this.backToTopType = 'backToTopElementComponent';
+    this.datePickerType = 'datePickerElementComponent';
+    this.separatorType = 'separatorElementComponent';
+    this.imageType = 'imageElementComponent';
+    this.videoType = 'videoElementComponent';
+    this.goToSaveCPType = 'goToSaveCpElementComponent';
 
   }
 

--- a/src/app/elements/element-selection-tab/go-to-save-cp-element/go-to-save-cp-element.component.css
+++ b/src/app/elements/element-selection-tab/go-to-save-cp-element/go-to-save-cp-element.component.css
@@ -1,0 +1,11 @@
+app-text-element{
+    background: black;
+}
+.row {
+    margin-left: 20px;
+    margin-right: 20px;
+}
+
+button {
+    margin-right: 5px;
+}

--- a/src/app/elements/element-selection-tab/go-to-save-cp-element/go-to-save-cp-element.component.html
+++ b/src/app/elements/element-selection-tab/go-to-save-cp-element/go-to-save-cp-element.component.html
@@ -1,0 +1,9 @@
+<div class="row" style="margin-top: 15px;">
+    <div class="cp_go-to-save-cp-container">
+        <button class="cp_go-to-save-cp-button"
+                alt="Click here to save the Care Plan" style="margin-top:15px; margin-bottom:15px;">Go to Save Care Plan</button>
+    </div>
+    <button (click)="removeElement()">REMOVE</button>
+    <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+    <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
+</div>

--- a/src/app/elements/element-selection-tab/go-to-save-cp-element/go-to-save-cp-element.component.ts
+++ b/src/app/elements/element-selection-tab/go-to-save-cp-element/go-to-save-cp-element.component.ts
@@ -2,17 +2,17 @@ import {Component, EventEmitter, Input, OnInit, Output, ViewChild, ViewContainer
 import {ElementsComponent} from "../../elements.component";
 
 @Component({
-  selector: 'app-back-to-top',
-  templateUrl: './back-to-top.component.html',
-  styleUrls: ['./back-to-top.component.css']
+  selector: 'app-go-to-save-cp-element',
+  templateUrl: './go-to-save-cp-element.component.html',
+  styleUrls: ['./go-to-save-cp-element.component.css']
 })
-export class BackToTopComponent implements OnInit{
-  @Input() name: string = '';
-  @Input() position: number;
+export class GoToSaveCpElementComponent implements OnInit{
+@Input() name: string = '';
+@Input() position: number;
 
-  @Output() removedElement = new EventEmitter<any>();
-  @Output() updateHtml = new EventEmitter<any>();
-  @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef;
+@Output() removedElement = new EventEmitter<any>();
+@Output() updateHtml = new EventEmitter<any>();
+@ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef;
 
   htmlValue = this.generateHtml();
 
@@ -21,7 +21,10 @@ export class BackToTopComponent implements OnInit{
   }
 
   generateHtml() {
-    return '     <button class="cp_button-back-to-top" title="Back to Top" ><a href="#top">Back To Top</a></button>';
+    return '' +
+    '      <div class="cp_go-to-save-cp-container">\n' +
+    '        <button class="cp_go-to-save-cp-button" title="Back to Top" style="margin-top:15px; margin-bottom:15px;"><a href="#fileUploadForm_save">Go to Save Care Plan</a></button>\n' +
+    '      </div>';
   }
 
   constructor(public elementComponent: ElementsComponent) {}
@@ -48,5 +51,8 @@ export class BackToTopComponent implements OnInit{
       }
 
     })();
+  }
+  moveDownElement(){
+
   }
 }

--- a/src/app/elements/element-selection-tab/image-element/image-element-dialog/image-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/image-element/image-element-dialog/image-element-dialog.component.html
@@ -1,0 +1,12 @@
+<div><h1 mat-dialog-title>Edit Input Field</h1>
+    <label>Label </label>
+    <input matInput [(ngModel)]="label" value=""><br>
+    <label>Image Source </label>
+    <input matInput [(ngModel)]="src" value="" placeholder="Source path of the image"><br>
+    <div mat-dialog-actions>
+        <button [mat-dialog-close]="[label, src]">Save</button>
+        <button [mat-dialog-close]="[]">Cancel</button>
+    </div>
+</div>
+
+

--- a/src/app/elements/element-selection-tab/image-element/image-element-dialog/image-element-dialog.component.ts
+++ b/src/app/elements/element-selection-tab/image-element/image-element-dialog/image-element-dialog.component.ts
@@ -1,0 +1,18 @@
+import {Component, Inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
+import {DialogData} from "../../input-element/input-element-dialog/input-element-dialog.component";
+
+@Component({
+  selector: 'app-image-element-dialog',
+  templateUrl: './image-element-dialog.component.html',
+  styleUrls: ['./image-element-dialog.component.css']
+})
+export class ImageElementDialogComponent {
+  public label: string;
+  public src: string;
+
+  constructor(public dialogRef: MatDialogRef<ImageElementDialogComponent>, @Inject(MAT_DIALOG_DATA) public data: DialogData) {
+    this.label = data.label;
+    this.src = data.src;
+  }
+}

--- a/src/app/elements/element-selection-tab/image-element/image-element.component.css
+++ b/src/app/elements/element-selection-tab/image-element/image-element.component.css
@@ -1,0 +1,8 @@
+.row {
+    margin-left: 20px;
+    margin-right: 20px;
+}
+button {
+    margin-right: 5px;
+}
+

--- a/src/app/elements/element-selection-tab/image-element/image-element.component.html
+++ b/src/app/elements/element-selection-tab/image-element/image-element.component.html
@@ -1,0 +1,14 @@
+<div class="row" style="margin-top: 15px;">
+    <div>
+        <label class="cp_label input-group" >{{label}}</label><br>
+        <img class="cp_image"
+             [ngSrc]="src"
+             alt="ALT TEXT" style="max-width: 360px; max-height: 360px;  margin: auto;"
+             width="100%"
+             height="auto">
+    </div>
+    <button (click)="openDialog()">EDIT</button>
+    <button (click)="removeElement()">REMOVE</button>
+    <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+    <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
+</div>

--- a/src/app/elements/element-selection-tab/image-element/image-element.component.ts
+++ b/src/app/elements/element-selection-tab/image-element/image-element.component.ts
@@ -1,0 +1,70 @@
+import {Component, EventEmitter, Input, Output, ViewChild, ViewContainerRef} from '@angular/core';
+import {ElementType} from "../element-selection-tab.component";
+import {MatDialog} from "@angular/material/dialog";
+import {ElementsComponent} from "../../elements.component";
+import {InputElementDialogComponent} from "../input-element/input-element-dialog/input-element-dialog.component";
+import {ImageElementDialogComponent} from "./image-element-dialog/image-element-dialog.component";
+
+@Component({
+  selector: 'app-image-element',
+  templateUrl: './image-element.component.html',
+  styleUrls: ['./image-element.component.css']
+})
+export class ImageElementComponent implements ElementType {
+  @Input() name: string = '';
+  @Input() position: number;
+
+  @Output() moveUpElement = new EventEmitter<any>();
+  @Output() removedElement = new EventEmitter<any>();
+  @Output() updateHtml = new EventEmitter<any>();
+  @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef;
+
+  label: string = 'LABEL';
+  src: string = '';
+  htmlValue = this.generateHtml();
+
+  generateHtml() {
+    return '' +
+        '      <div class="cp_image-element">\n' +
+        '        <label class="cp_image-elementlabel input-group" >' + this.label + '</label><br>\n' +
+        '        <img class="cp_image" src="' + this.src + '" alt="ALT TEXT" style="max-width: 360px; max-height: 360px; margin: auto;" width="100%" height="auto">\n' +
+        '      </div>';
+  }
+
+  constructor(public dialog: MatDialog, public elementComponent: ElementsComponent) {
+  }
+
+  openDialog(): void {
+    if (!this.elementComponent.isDialogOpen) {
+      this.elementComponent.changeDialogState();
+      const dialogRef = this.dialog.open(ImageElementDialogComponent, {
+        data: {label: this.label, src: this.src},
+      });
+
+      dialogRef.afterClosed().subscribe(result => {
+        this.elementComponent.changeDialogState();
+        if (result.length != 0){
+          if (result[0] !== this.label) {
+            this.label = result[0];
+          }
+          if (result[1] !== '') {
+            this.src = result[1];
+          }
+        }
+
+        this.htmlValue = this.generateHtml();
+        this.updateHtml.emit({
+          label: this.label,
+          src: this.src,
+        })
+      });
+    }
+  }
+
+  removeElement() {
+    this.removedElement.emit({
+      name: this.name,
+    })
+  }
+}
+

--- a/src/app/elements/element-selection-tab/input-element/input-element-dialog/input-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/input-element/input-element-dialog/input-element-dialog.component.html
@@ -7,7 +7,7 @@
 <input matInput [(ngModel)]="helpText" value="">
 <div mat-dialog-actions>
   <button [mat-dialog-close]="[label, placeholder, helpText]">Save</button>
-  <button [mat-dialog-close]="">Cancel</button>
+  <button [mat-dialog-close]="[]">Cancel</button>
 </div>
 </div>
 

--- a/src/app/elements/element-selection-tab/input-element/input-element-dialog/input-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/input-element/input-element-dialog/input-element-dialog.component.html
@@ -1,9 +1,9 @@
 <div><h1 mat-dialog-title>Edit Input Field</h1>
-<label>Label</label>
+<label>Label </label>
 <input matInput [(ngModel)]="label" value=""><br>
-<label>Placeholder</label>
+<label>Placeholder </label>
 <input matInput [(ngModel)]="placeholder" value=""><br>
-<label>Help Text</label>
+<label>Help Text </label>
 <input matInput [(ngModel)]="helpText" value="">
 <div mat-dialog-actions>
   <button [mat-dialog-close]="[label, placeholder, helpText]">Save</button>

--- a/src/app/elements/element-selection-tab/input-element/input-element-dialog/input-element-dialog.component.ts
+++ b/src/app/elements/element-selection-tab/input-element/input-element-dialog/input-element-dialog.component.ts
@@ -8,6 +8,7 @@ export interface DialogData {
   selectOptionValues: string[]
   inputValues: string[]
   checkBoxValues: string[]
+  src: string
 }
 @Component({
   selector: 'app-input-element-dialog',
@@ -16,7 +17,6 @@ export interface DialogData {
 })
 @Injectable()
 export class InputElementDialogComponent {
-  save = new EventEmitter<any>();
   public label: string;
   public placeholder: string;
   public helpText: string;
@@ -25,11 +25,6 @@ export class InputElementDialogComponent {
     this.label = data.label;
     this.placeholder = data.placeholder;
     this.helpText = data.helpText;
-  }
-
-
-  onNoClick(): void {
-    this.dialogRef.close();
   }
 
 }

--- a/src/app/elements/element-selection-tab/input-element/input-element.component.html
+++ b/src/app/elements/element-selection-tab/input-element/input-element.component.html
@@ -1,4 +1,4 @@
-<div class="row" style="margin-top: 15px;" [ngStyle]="{'order': position}">
+<div class="row" style="margin-top: 15px;" cdkDropList>
   <div class="col-sm-6 input-group">
     <label class="cp-label cp-input-with-label">{{label}}</label></div>
   <div class="col-sm-6 input-group" style="margin-top: 15px;">
@@ -7,6 +7,6 @@
   </div>
   <button (click)="openDialog()">EDIT</button>
   <button (click)="removeElement()">REMOVE</button>
-  <button (click)="elementComponent.moveComponentDown(position, name)">MOVE DOWN</button>
-  <button (click)="elementComponent.moveComponentUp(position, name)">MOVE UP</button>
+  <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+  <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
 </div>

--- a/src/app/elements/element-selection-tab/input-element/input-element.component.html
+++ b/src/app/elements/element-selection-tab/input-element/input-element.component.html
@@ -1,4 +1,4 @@
-<div class="row" style="margin-top: 15px;" cdkDropList>
+<div class="row" style="margin-top: 15px;">
   <div class="col-sm-6 input-group">
     <label class="cp-label cp-input-with-label">{{label}}</label></div>
   <div class="col-sm-6 input-group" style="margin-top: 15px;">

--- a/src/app/elements/element-selection-tab/input-element/input-element.component.ts
+++ b/src/app/elements/element-selection-tab/input-element/input-element.component.ts
@@ -20,38 +20,36 @@ export class InputElementComponent implements ElementType {
   @Output() updateHtml = new EventEmitter<any>();
   @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef;
 
-  helpText: string = '';
+  helpText: string = 'HELP TEXT';
   label: string = 'LABEL';
   placeholder: string = 'PLACEHOLDER';
   htmlValue = this.generateHtml();
 
   generateHtml() {
-    return ' <div class="row cp_input-element" style="margin-top: 15px;">\n' +
-      '  <div class="col-sm-6 input-group">\n' +
-      '    <label class="cp-label cp-input-with-label">' + this.label + '</label></div>\n' +
-      '  <div class="col-sm-6 input-group" style="margin-top: 15px;">\n' +
-      '    <input type="text" class="cp_input form-control" style="width: 100%;" placeholder="' + this.placeholder + '" value=""/>\n' +
-      '    <span>' + this.helpText + ' </span>\n' +
-      '  </div>\n' +
-      '</div>\n';
+    return '      <div class="row cp_input-element" style="margin-top: 15px;">\n' +
+      '          <div class="col-sm-6 input-group">\n' +
+      '             <label class="cp-label cp-input-with-label">' + this.label + '</label></div>\n' +
+      '             <div class="col-sm-6 input-group" style="margin-top: 15px;">\n' +
+      '               <input type="text" class="cp_input form-control" style="width: 100%;" placeholder="' + this.placeholder + '" value="">\n' +
+      '               <span>' + this.helpText + '</span>\n' +
+      '             </div>\n' +
+      '       </div>';
   }
 
   constructor(public dialog: MatDialog, public elementComponent: ElementsComponent) {
-    this.placeholder = '';
-    this.label = 'LABEL';
-    this.helpText = 'HELP TEXT';
   }
 
   openDialog(): void {
     if (!this.elementComponent.isDialogOpen) {
-      this.elementComponent.changeDialogOpenSate();
+      this.elementComponent.changeDialogState();
       const dialogRef = this.dialog.open(InputElementDialogComponent, {
         data: {label: this.label, placeholder: this.placeholder, helpText: this.helpText},
       });
 
       dialogRef.afterClosed().subscribe(result => {
-        this.elementComponent.changeDialogOpenSate();
-        if (result[0] !== '') {
+        this.elementComponent.changeDialogState();
+        if (result.length != 0){
+        if (result[0] !== this.label) {
           this.label = result[0];
         }
         if (result[1] !== '') {
@@ -60,7 +58,7 @@ export class InputElementComponent implements ElementType {
         if (result[2] !== '') {
           this.helpText = result[2];
         }
-
+        }
 
         this.htmlValue = this.generateHtml();
         this.updateHtml.emit({

--- a/src/app/elements/element-selection-tab/radio-element/radio-element-dialog/radio-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/radio-element/radio-element-dialog/radio-element-dialog.component.html
@@ -1,7 +1,7 @@
 <div><h1 mat-dialog-title>Edit Input Field</h1>
-    <label>Label</label>
+    <label>Label </label>
     <input matInput [(ngModel)]="label" value=""><br>
-    <button (click)="addRadioButton()">Add option</button>
+    <button (click)="addRadioButton()">Add option </button>
 </div>
 <div *ngFor="let radioElement of radioElementValues; let i=index"> Option text
     <input value="" [(ngModel)]="bufferRadioElementValues[i]">

--- a/src/app/elements/element-selection-tab/radio-element/radio-element-dialog/radio-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/radio-element/radio-element-dialog/radio-element-dialog.component.html
@@ -10,6 +10,6 @@
 </div>
 <div mat-dialog-actions>
     <button (click)="populateRadioElements()" [mat-dialog-close]="[label, radioElementValues]">Save</button>
-    <button [mat-dialog-close]="">Cancel</button>
+    <button [mat-dialog-close]="[]">Cancel</button>
 </div>
 

--- a/src/app/elements/element-selection-tab/radio-element/radio-element-dialog/radio-element-dialog.component.ts
+++ b/src/app/elements/element-selection-tab/radio-element/radio-element-dialog/radio-element-dialog.component.ts
@@ -30,7 +30,6 @@ export class RadioElementDialogComponent {
   }
 
   removeRadioButton(indexOfTheElement: number){
-    console.log(indexOfTheElement)
     if (this.radioElementValues.length > 1) {
       this.radioElementValues.splice(indexOfTheElement,1);
       this.bufferRadioElementValues.splice(indexOfTheElement, 1);

--- a/src/app/elements/element-selection-tab/radio-element/radio-element.component.html
+++ b/src/app/elements/element-selection-tab/radio-element/radio-element.component.html
@@ -10,6 +10,6 @@
   </div>
   <button (click)="openDialog()">EDIT</button>
   <button (click)="removeElement()">REMOVE</button>
-  <button (click)="elementComponent.moveComponentDown(position, name)">MOVE DOWN</button>
-  <button (click)="elementComponent.moveComponentUp(position, name)">MOVE UP</button>
+  <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+  <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
 </div>

--- a/src/app/elements/element-selection-tab/radio-element/radio-element.component.ts
+++ b/src/app/elements/element-selection-tab/radio-element/radio-element.component.ts
@@ -20,12 +20,11 @@ export class RadioElementComponent implements ElementType {
   htmlValue = this.generateHtml();
 
   generateHtml() {
-    return ' <div class="row cp_radio-element" style="margin-top: 15px;">\n' +
-      '  <div class="col-sm-6 input-group">\n' +
-      '   <p class="cp_label">\n' + this.label +
-      '   </p>\n' +
-      '  </div>\n' + this.generateRadioOptions() +
-      ' </div>\n'
+    return '     <div class="row cp_radio-element" style="margin-top: 15px;">\n' +
+      '       <div class="cp_radio-element-label input-group">\n' +
+      '         <label class="cp_label">' + this.label + '</label>\n' +
+      '       </div>\n' + this.generateRadioOptions() +
+      '     </div>'
   }
   constructor(public dialog: MatDialog, public elementComponent: ElementsComponent) {
     this.label = 'LABEL';
@@ -33,32 +32,33 @@ export class RadioElementComponent implements ElementType {
 
   openDialog(): void {
     if (!this.elementComponent.isDialogOpen) {
-      this.elementComponent.changeDialogOpenSate();
+      this.elementComponent.changeDialogState();
       const dialogRef = this.dialog.open(RadioElementDialogComponent, {
         data: {label: this.label, inputValues: this.radioButtonValues},
       });
 
       dialogRef.afterClosed().subscribe(result => {
-        this.elementComponent.changeDialogOpenSate();
-        if (result[0] !== '') {
-          this.label = result[0];
-          this.htmlValue = this.generateHtml();
-          this.updateHtml.emit({
-            label: this.label,
-          })
+        this.elementComponent.changeDialogState();
+        if (result.length != 0) {
+          if (result[0] !== '') {
+            this.label = result[0];
+            this.htmlValue = this.generateHtml();
+            this.updateHtml.emit({
+              label: this.label,
+            })
+          }
         }
-      });
+        });
     }
   }
 
   generateRadioOptions(){
     let options = '';
-    console.log(this.radioButtonValues)
     for (let i = 0; i < this.radioButtonValues.length; i++) {
-      options +=       '  <div class="form-check input-group">\n' +
-          '    <input class="cp_input form-check-input col-xs-1" type="radio" name="cp-radio-button-element-name" value="'+ this.radioButtonValues[i] + '">\n' +
-          '    <label class="cp_label form-check-label col-xs-10" value="' + this.radioButtonValues[i] +'">' + this.radioButtonValues[i] + '</label>\n' +
-          '  </div>\n';
+      options += '         <div class="form-check input-group">\n' +
+          '           <input class="cp_radio-element-input" type="radio" name="cp-radio-button-element-name" value="'+ this.radioButtonValues[i] + '">\n' +
+          '           <label class="cp_radio-element-input-label">' + this.radioButtonValues[i] + '</label>\n' +
+          '       </div>\n';
     }
     return options;
   }

--- a/src/app/elements/element-selection-tab/select-element/select-element-dialog/select-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/select-element/select-element-dialog/select-element-dialog.component.html
@@ -1,7 +1,7 @@
 <div><h1 mat-dialog-title>Edit Input Field</h1>
-  <label>Label</label>
+  <label>Label </label>
   <input matInput [(ngModel)]="label" value=""><br>
-  <button (click)="addOption()">Add option</button>
+  <button (click)="addOption()">Add option </button>
 </div>
 <div *ngFor="let option of selectOptionValues; let i=index"> Option text
   <input value="" [(ngModel)]="bufferOptionValues[i]"><button *ngIf="selectOptionValues.length > 2" (click)="removeOption(i)"> REMOVE </button><br>

--- a/src/app/elements/element-selection-tab/select-element/select-element-dialog/select-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/select-element/select-element-dialog/select-element-dialog.component.html
@@ -8,5 +8,5 @@
 </div>
 <div mat-dialog-actions>
   <button (click)="populatingOptionValues()" [mat-dialog-close]="[label, selectOptionValues]">Save</button>
-  <button [mat-dialog-close]="">Cancel</button>
+  <button [mat-dialog-close]="[]">Cancel</button>
 </div>

--- a/src/app/elements/element-selection-tab/select-element/select-element-dialog/select-element-dialog.component.ts
+++ b/src/app/elements/element-selection-tab/select-element/select-element-dialog/select-element-dialog.component.ts
@@ -38,7 +38,6 @@ export class SelectElementDialogComponent {
   }
 
   removeOption(indexOfTheElement: number){
-    console.log(indexOfTheElement)
     if (this.selectOptionValues.length > 1) {
       this.selectOptionValues.splice(indexOfTheElement,1);
       this.bufferOptionValues.splice(indexOfTheElement, 1);

--- a/src/app/elements/element-selection-tab/select-element/select-element.component.html
+++ b/src/app/elements/element-selection-tab/select-element/select-element.component.html
@@ -10,6 +10,6 @@
   </div>
   <button (click)="openDialog()">EDIT</button>
   <button (click)="removeElement()">REMOVE</button>
-  <button (click)="elementComponent.moveComponentDown(position, name)">MOVE DOWN</button>
-  <button (click)="elementComponent.moveComponentUp(position, name)">MOVE UP</button>
+  <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+  <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
 </div>

--- a/src/app/elements/element-selection-tab/select-element/select-element.component.ts
+++ b/src/app/elements/element-selection-tab/select-element/select-element.component.ts
@@ -54,25 +54,14 @@ export class SelectElementComponent implements ElementType, OnInit {
       dialogRef.afterClosed().subscribe(result => {
         this.elementComponent.changeDialogState();
         if (result.length != 0){
-            if (result[0] !== '') {
-              this.label = result[0];
-              //this.selectOptionValues = result[1]
-              this.htmlValue = this.generateHtml();
-              this.updateHtml.emit({
-                label: this.label,
-              })
-            }
+          if (result[0] !== '') {
+            this.label = result[0];
+            this.htmlValue = this.generateHtml();
+            this.updateHtml.emit({
+              label: this.label,
+            })
           }
-        this.elementComponent.changeDialogState();
-        if (result.length != 0){
-            if (result[0] !== '') {
-              this.label = result[0];
-              this.htmlValue = this.generateHtml();
-              this.updateHtml.emit({
-                label: this.label,
-              })
-            }
-          }
+        }
       });
     }
   }

--- a/src/app/elements/element-selection-tab/select-element/select-element.component.ts
+++ b/src/app/elements/element-selection-tab/select-element/select-element.component.ts
@@ -27,45 +27,41 @@ export class SelectElementComponent implements ElementType, OnInit {
   ngOnInit() {}
 
   generateHtml(){
-    return ' <div class="row cp_select-with-label" style="margin-top: 15px;">\n' +
-    '  <div class="col-sm-6 input-group">\n' +
-    '   <label class="cp_label input-group">' + this.label +
-    '   </label>\n' +
-    '  </div>\n' +
-    '  <div class="col-sm-6 input-group" style="margin-top: 15px;">\n' +
-    '   <select class="form-control input-group cp_select" >\n' + this.generateOptions() +
-    '   </select>\n' +
-    '  </div>\n' +
-    ' </div>\n'
+    return '     <div class="row cp_select-element" style="margin-top: 15px;">\n' +
+    '          <label class="cp_select-element-label input-group">' + this.label + '</label>\n' +
+    '            <div class="cp_select-element-selection" style="margin-top: 15px;">\n' +
+    '              <select class="cp_select" >' + this.generateOptions() +
+    '              </select>\n' +
+    '          </div>\n' +
+    '     </div>'
   }
 
   generateOptions() {
     let options = '';
     for (let i = 0; i < this.selectOptionValues.length; i++) {
-      console.log('selectOptionValues[i]: ' + this.selectOptionValues[i])
-      options += '    <option class="cp-select-option" value="' + this.selectOptionValues[i] + '">' + this.selectOptionValues[i] + '\n' +
-      '    </option>\n'
+      options += '              <option class="cp_select-option" value="' + this.selectOptionValues[i] + '">' + this.selectOptionValues[i] + '</option>\n'
     }
     return options;
   }
 
   openDialog(): void {
     if (!this.elementComponent.isDialogOpen) {
-      this.elementComponent.changeDialogOpenSate();
+      this.elementComponent.changeDialogState();
       const dialogRef = this.dialog.open(SelectElementDialogComponent, {
         data: {label: this.label, selectOptionValues: this.selectOptionValues}
       });
 
       dialogRef.afterClosed().subscribe(result => {
-        this.elementComponent.changeDialogOpenSate();
-        if (result[0] !== '') {
-          this.label = result[0];
-          //this.selectOptionValues = result[1]
-          this.htmlValue = this.generateHtml();
-          this.updateHtml.emit({
-            label: this.label,
-          })
-        }
+        this.elementComponent.changeDialogState();
+        if (result.length != 0){
+            if (result[0] !== '') {
+              this.label = result[0];
+              this.htmlValue = this.generateHtml();
+              this.updateHtml.emit({
+                label: this.label,
+              })
+            }
+          }
       });
     }
   }

--- a/src/app/elements/element-selection-tab/select-element/select-element.component.ts
+++ b/src/app/elements/element-selection-tab/select-element/select-element.component.ts
@@ -56,6 +56,17 @@ export class SelectElementComponent implements ElementType, OnInit {
         if (result.length != 0){
             if (result[0] !== '') {
               this.label = result[0];
+              //this.selectOptionValues = result[1]
+              this.htmlValue = this.generateHtml();
+              this.updateHtml.emit({
+                label: this.label,
+              })
+            }
+          }
+        this.elementComponent.changeDialogState();
+        if (result.length != 0){
+            if (result[0] !== '') {
+              this.label = result[0];
               this.htmlValue = this.generateHtml();
               this.updateHtml.emit({
                 label: this.label,

--- a/src/app/elements/element-selection-tab/separator-element/separator-element.component.css
+++ b/src/app/elements/element-selection-tab/separator-element/separator-element.component.css
@@ -1,0 +1,8 @@
+.row {
+    margin-left: 20px;
+    margin-right: 20px;
+}
+button {
+    margin-right: 5px;
+}
+

--- a/src/app/elements/element-selection-tab/separator-element/separator-element.component.html
+++ b/src/app/elements/element-selection-tab/separator-element/separator-element.component.html
@@ -1,0 +1,7 @@
+<div class="row" style="margin-top: 15px;">
+    <hr class="cp_separator" style="height: 3px; background-color: black; margin: 50px auto;width: 80%;"/>
+    <button (click)="removeElement()">REMOVE</button>
+    <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+    <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
+</div>
+

--- a/src/app/elements/element-selection-tab/separator-element/separator-element.component.ts
+++ b/src/app/elements/element-selection-tab/separator-element/separator-element.component.ts
@@ -1,0 +1,34 @@
+import {Component, EventEmitter, Input, Output, ViewChild, ViewContainerRef} from '@angular/core';
+import {ElementType} from "../element-selection-tab.component";
+import {ElementsComponent} from "../../elements.component";
+
+@Component({
+  selector: 'app-separator-element',
+  templateUrl: './separator-element.component.html',
+  styleUrls: ['./separator-element.component.css']
+})
+export class SeparatorElementComponent implements ElementType {
+  @Input() name: string = '';
+  @Input() position: number;
+
+  @Output() moveUpElement = new EventEmitter<any>();
+  @Output() removedElement = new EventEmitter<any>();
+  @Output() updateHtml = new EventEmitter<any>();
+  @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef;
+
+  htmlValue = this.generateHtml();
+
+  generateHtml() {
+    return '      <hr class="cp_separator" style="height: 3px; background-color: black; margin: 50px auto;width: 80%;"/>';
+  }
+
+  constructor(public elementComponent: ElementsComponent) {
+  }
+
+  removeElement() {
+    this.removedElement.emit({
+      name: this.name,
+    })
+  }
+}
+

--- a/src/app/elements/element-selection-tab/text-element/text-element-dialog/text-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/text-element/text-element-dialog/text-element-dialog.component.html
@@ -3,6 +3,6 @@
   <input matInput [(ngModel)]="label" value=""><br>
   <div mat-dialog-actions>
     <button [mat-dialog-close]="[label]">Save</button>
-    <button [mat-dialog-close]="">Cancel</button>
+    <button [mat-dialog-close]="[]">Cancel</button>
   </div>
 </div>

--- a/src/app/elements/element-selection-tab/text-element/text-element-dialog/text-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/text-element/text-element-dialog/text-element-dialog.component.html
@@ -1,5 +1,5 @@
 <div><h1 mat-dialog-title>Edit Input Field</h1>
-  <label>Label</label>
+  <label>Label </label>
   <input matInput [(ngModel)]="label" value=""><br>
   <div mat-dialog-actions>
     <button [mat-dialog-close]="[label]">Save</button>

--- a/src/app/elements/element-selection-tab/text-element/text-element.component.html
+++ b/src/app/elements/element-selection-tab/text-element/text-element.component.html
@@ -7,6 +7,6 @@
   </div>
   <button (click)="openDialog()">EDIT</button>
   <button (click)="removeElement()">REMOVE</button>
-  <button (click)="elementComponent.moveComponentDown(position, name)">MOVE DOWN</button>
-  <button (click)="elementComponent.moveComponentUp(position, name)">MOVE UP</button>
+  <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+  <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
 </div>

--- a/src/app/elements/element-selection-tab/text-element/text-element.component.ts
+++ b/src/app/elements/element-selection-tab/text-element/text-element.component.ts
@@ -19,13 +19,12 @@ export class TextElementComponent implements ElementType {
   htmlValue = this.generateHtml();
 
   generateHtml(){
-    return '   <div class="row" style="margin-top: 15px;">\n' +
-      '    <div class="col-sm-12 input-group">\n' +
-      '      <label class="cp_label cp-text-area-input-with-label" >' + this.label +
-      '      </label>\n' +
-      '      <textarea class="form-control" rows="3" style="width: 100%;"></textarea>\n' +
-      '    </div>\n' +
-      '  </div>\n'
+    return '     <div class="row cp_text-element" style="margin-top: 15px;">\n' +
+      '       <div class="cp_text-element-group">\n' +
+      '          <label class="cp_text-element-label" >' + this.label + '</label>\n' +
+      '          <textarea class="cp_text-element-text-area" rows="3" style="width: 100%;"></textarea>\n' +
+      '       </div>\n' +
+      '    </div>'
   }
 
   constructor(public dialog: MatDialog, public elementComponent: ElementsComponent) {
@@ -41,19 +40,21 @@ export class TextElementComponent implements ElementType {
 
   openDialog(): void {
     if (!this.elementComponent.isDialogOpen) {
-      this.elementComponent.changeDialogOpenSate();
+      this.elementComponent.changeDialogState();
       const dialogRef = this.dialog.open(TextElementDialogComponent, {
         data: {label: this.label},
       });
 
       dialogRef.afterClosed().subscribe(result => {
-        this.elementComponent.changeDialogOpenSate();
-        if (result[0] !== '') {
-          this.label = result[0];
-          this.htmlValue = this.generateHtml();
-          this.updateHtml.emit({
-            label: this.label,
-          })
+        this.elementComponent.changeDialogState();
+        if (result.length != 0) {
+          if (result[0] !== '') {
+            this.label = result[0];
+            this.htmlValue = this.generateHtml();
+            this.updateHtml.emit({
+              label: this.label,
+            })
+          }
         }
       });
     }

--- a/src/app/elements/element-selection-tab/video-element/video-element-dialog/video-element-dialog.component.html
+++ b/src/app/elements/element-selection-tab/video-element/video-element-dialog/video-element-dialog.component.html
@@ -1,0 +1,9 @@
+<div><h1 mat-dialog-title>Edit Input Field</h1>
+    <label>Video Source </label>
+    <input matInput [(ngModel)]="src" value="" placeholder="E.g. youtube.com/example"><br>
+    <div mat-dialog-actions>
+        <button [mat-dialog-close]="[src]">Save</button>
+        <button [mat-dialog-close]="[]">Cancel</button>
+    </div>
+</div>
+

--- a/src/app/elements/element-selection-tab/video-element/video-element-dialog/video-element-dialog.component.ts
+++ b/src/app/elements/element-selection-tab/video-element/video-element-dialog/video-element-dialog.component.ts
@@ -1,0 +1,16 @@
+import {Component, Inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
+import {DialogData} from "../../input-element/input-element-dialog/input-element-dialog.component";
+
+@Component({
+  selector: 'app-video-element-dialog',
+  templateUrl: './video-element-dialog.component.html',
+  styleUrls: ['./video-element-dialog.component.css']
+})
+export class VideoElementDialogComponent {
+  public src: string;
+
+  constructor(public dialogRef: MatDialogRef<VideoElementDialogComponent>, @Inject(MAT_DIALOG_DATA) public data: DialogData) {
+    this.src = data.src;
+  }
+}

--- a/src/app/elements/element-selection-tab/video-element/video-element.component.css
+++ b/src/app/elements/element-selection-tab/video-element/video-element.component.css
@@ -1,0 +1,11 @@
+app-text-element{
+    background: black;
+}
+.row {
+    margin-left: 20px;
+    margin-right: 20px;
+}
+
+button {
+    margin-right: 5px;
+}

--- a/src/app/elements/element-selection-tab/video-element/video-element.component.html
+++ b/src/app/elements/element-selection-tab/video-element/video-element.component.html
@@ -1,0 +1,10 @@
+<div class="row" style="margin-top: 15px;">
+    <div class="cp_video_element" style="margin: auto;">
+        <iframe class="cp_video-element-iframe" width="520" height="260" [src]="src" allowfullscreen></iframe>
+    </div>
+    <button (click)="openDialog()">EDIT</button>
+    <button (click)="removeElement()">REMOVE</button>
+    <button (click)="elementComponent.moveDown(position, name)">MOVE DOWN</button>
+    <button (click)="elementComponent.moveUp(position, name)">MOVE UP</button>
+</div>
+

--- a/src/app/elements/element-selection-tab/video-element/video-element.component.ts
+++ b/src/app/elements/element-selection-tab/video-element/video-element.component.ts
@@ -1,0 +1,65 @@
+import {Component, EventEmitter, Input, Output, ViewChild, ViewContainerRef} from '@angular/core';
+import {ElementType} from "../element-selection-tab.component";
+import {MatDialog} from '@angular/material/dialog';
+
+import {ElementsComponent} from "../../elements.component";
+import {VideoElementDialogComponent} from "./video-element-dialog/video-element-dialog.component";
+
+
+@Component({
+  selector: 'app-video-element',
+  templateUrl: './video-element.component.html',
+  styleUrls: ['./video-element.component.css']
+})
+export class VideoElementComponent implements ElementType {
+  @Input() name: string = '';
+  @Input() position: number;
+
+  @Output() moveUpElement = new EventEmitter<any>();
+  @Output() removedElement = new EventEmitter<any>();
+  @Output() updateHtml = new EventEmitter<any>();
+  @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef;
+
+  src: string = "https://www.youtube.com/embed/PibKTwL-Jig?si=vUPGiINkJU_7tiTo";
+  htmlValue = this.generateHtml();
+
+  generateHtml() {
+    return '' +
+        '      <div class="cp_video_element" style="margin: auto;">\n' +
+        '        <iframe width="520" height="260" allowfullscreen="true" class="cp_video-element-iframe" src="' + this.src +'"></iframe>\n' +
+        '      </div>';
+  }
+
+  constructor(public dialog: MatDialog, public elementComponent: ElementsComponent) {
+  }
+
+  openDialog(): void {
+    if (!this.elementComponent.isDialogOpen) {
+      this.elementComponent.changeDialogState();
+      const dialogRef = this.dialog.open(VideoElementDialogComponent, {
+        data: {src: this.src},
+      });
+
+      dialogRef.afterClosed().subscribe(result => {
+        this.elementComponent.changeDialogState();
+        if (result.length != 0){
+          if (result[0] !== this.src) {
+            this.src = result[0];
+          }
+        }
+
+        this.htmlValue = this.generateHtml();
+        this.updateHtml.emit({
+          src: this.src,
+        })
+      });
+    }
+  }
+
+  removeElement() {
+    this.removedElement.emit({
+      name: this.name,
+    })
+  }
+}
+

--- a/src/app/elements/elements.component.ts
+++ b/src/app/elements/elements.component.ts
@@ -6,6 +6,13 @@ import {SelectElementComponent} from "./element-selection-tab/select-element/sel
 import {RadioElementComponent} from "./element-selection-tab/radio-element/radio-element.component";
 import {CheckboxElementComponent} from "./element-selection-tab/checkbox-element/checkbox-element.component";
 import {BackToTopComponent} from "./element-selection-tab/back-to-top/back-to-top.component";
+import {DatePickerElementComponent} from "./element-selection-tab/date-picker/date-picker-element.component";
+import {SeparatorElementComponent} from "./element-selection-tab/separator-element/separator-element.component";
+import {ImageElementComponent} from "./element-selection-tab/image-element/image-element.component";
+import {VideoElementComponent} from "./element-selection-tab/video-element/video-element.component";
+import {
+  GoToSaveCpElementComponent
+} from "./element-selection-tab/go-to-save-cp-element/go-to-save-cp-element.component";
 
 @Component({
   selector: 'app-elements',
@@ -28,7 +35,12 @@ export class ElementsComponent implements OnInit {
     selectType: 'selectElementComponent',
     radioType: 'radioElementComponent',
     checkType: 'checkElementComponent',
-    backToTopType: 'backToTopElementComponent'
+    backToTopType: 'backToTopElementComponent',
+    datePickerType: 'datePickerElementComponent',
+    separatorType: 'separatorElementComponent',
+    imageType: 'imageElementComponent',
+    videoType: 'videoElementComponent',
+    goToSaveCPType: 'goToSaveCpElementComponent'
   }
 
   constructor(private service: Service) {
@@ -132,6 +144,26 @@ export class ElementsComponent implements OnInit {
       }
       case this.componentTypes.backToTopType: {
         actualType = BackToTopComponent;
+        break;
+      }
+      case this.componentTypes.datePickerType: {
+        actualType = DatePickerElementComponent;
+        break;
+      }
+      case this.componentTypes.separatorType: {
+        actualType = SeparatorElementComponent;
+        break;
+      }
+      case this.componentTypes.imageType: {
+        actualType = ImageElementComponent
+        break;
+      }
+      case this.componentTypes.videoType: {
+        actualType = VideoElementComponent
+        break;
+      }
+      case this.componentTypes.goToSaveCPType: {
+        actualType = GoToSaveCpElementComponent
         break;
       }
     }

--- a/src/app/elements/elements.component.ts
+++ b/src/app/elements/elements.component.ts
@@ -51,6 +51,7 @@ export class ElementsComponent implements OnInit {
     this.service.currentData.subscribe(m => this.components = m);
     this.service.currentPosition.subscribe(p => this.position = p);
     this.service.currentIndex.subscribe(i => this.indexNumber = i);
+    this.service.currentDialogState.subscribe(ds => this.isDialogOpen = ds);
   }
 
   public addComponent(componentName: string) {
@@ -173,6 +174,7 @@ export class ElementsComponent implements OnInit {
 
   changeDialogState(){
     this.isDialogOpen = !this.isDialogOpen;
+    this.service.changeDialogState(this.isDialogOpen);
   }
 
   deleteComponent(componentName: string) {

--- a/src/app/generate/generate.component.ts
+++ b/src/app/generate/generate.component.ts
@@ -23,24 +23,24 @@ constructor(private dataService: Service) {
   '    .form-group {width: 100%; !important}\n' +
   '    .cp_label {font-size: 18px;font-weight: 900;}\n' +
   '    .cp_whiteBox {background-color:#ffffff; padding:15px; margin-bottom:10px; margin-top:10px; border-radius: 10px; border: 3px solid #014151;}\n' +
-  '  </style>' +
+  '  </style>\n' +
   '    <div class="cp_whiteBox">'];
 
     if (this.mappedComponents.size > 0) {
-      let sortedComponentRefs: any = [];
+      let sortedComponentRefs: ComponentRef<any>[] = [];
 
-      this.mappedComponents.forEach((a,v) => {
-        let pos = a.instance?.position
-        sortedComponentRefs[pos] = a;
+      this.mappedComponents.forEach((component,key) => {
+        let position = component.instance?.position;
+          sortedComponentRefs[position] = component;
       })
 
-      for (let i = 0; i < sortedComponentRefs.length; i++) {
-        concatenatedCode.push(sortedComponentRefs[i].instance.htmlValue);
+      sortedComponentRefs.forEach((comp) => {
+        concatenatedCode.push(comp.instance.htmlValue);
         let actualCode = ''
         let s = function (){concatenatedCode.forEach((d)=> {actualCode+=d})}
-      }
+      })
 
-      concatenatedCode.push('</div>\n</div>');
+      concatenatedCode.push('  </div>\n</div>');
       let finalHtmlCode = concatenatedCode.join("\r\n")
       concatenatedCode.shift()
       this.dataService.setHtmlValue(finalHtmlCode);

--- a/src/app/nav/nav.component.html
+++ b/src/app/nav/nav.component.html
@@ -1,6 +1,6 @@
 <div class="cp-button-container">
-  <button class="button-3" id="clear-editor" (click)="emptyingTheEditor()">CLEAR EDITOR</button>
-  <button class="button-3" routerLink="./../elements-component">EDITOR</button>
-  <button class="button-3" routerLink="../generate-component">GENERATE</button>
-  <button class="button-3" routerLink="../preview-component">PREVIEW</button>
+  <button class="button-3" [disabled]="dialogState" id="clear-editor" (click)="emptyingTheEditor()">CLEAR EDITOR</button>
+  <button class="button-3" [disabled]="dialogState" routerLink="./../elements-component">EDITOR</button>
+  <button class="button-3" [disabled]="dialogState" routerLink="../generate-component">GENERATE</button>
+  <button class="button-3" [disabled]="dialogState" routerLink="../preview-component">PREVIEW</button>
 </div>

--- a/src/app/nav/nav.component.ts
+++ b/src/app/nav/nav.component.ts
@@ -1,6 +1,5 @@
 import {Component, ComponentRef, OnInit} from '@angular/core';
 import {Service} from "../service/service";
-import {GenerateComponent} from "../generate/generate.component";
 
 @Component({
   selector: 'app-nav',
@@ -10,12 +9,13 @@ import {GenerateComponent} from "../generate/generate.component";
 export class NavComponent implements OnInit {
 
   private mappedComponents: Map<string, ComponentRef<any>>;
-
+  public dialogState = false;
   constructor(private dataService: Service) {
   }
 
   ngOnInit() {
     this.dataService.currentData.subscribe(observedData => this.mappedComponents = observedData);
+    this.dataService.currentDialogState.subscribe(ds => this.dialogState = ds)
   }
 
   emptyingTheEditor() {

--- a/src/app/nav/nav.component.ts
+++ b/src/app/nav/nav.component.ts
@@ -10,7 +10,6 @@ import {GenerateComponent} from "../generate/generate.component";
 export class NavComponent implements OnInit {
 
   private mappedComponents: Map<string, ComponentRef<any>>;
-  private sumHtml: string;
 
   constructor(private dataService: Service) {
   }
@@ -29,5 +28,10 @@ export class NavComponent implements OnInit {
     this.mappedComponents.forEach((a,v) => {
       this.mappedComponents.delete(v)
     })
+    this.dataService.changeIndex(0);
+    this.dataService.changeCurrentData(new Map<string, ComponentRef<any>>())
+    this.dataService.setHtmlValue('')
+    this.dataService.changeIndex(0);
+    this.dataService.changePosition(0);
   }
 }

--- a/src/app/preview/preview.component.ts
+++ b/src/app/preview/preview.component.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit, Pipe, PipeTransform, ViewChild} from '@angular/core';
 import {Service} from "../service/service";
 import {DomSanitizer} from "@angular/platform-browser";
+import {GenerateComponent} from "../generate/generate.component";
 
 @Pipe({ name: "safeHtml" })
 export class SafeHtmlPipe implements PipeTransform {
@@ -23,10 +24,12 @@ export class PreviewComponent implements OnInit{
 
   htmlCode: string;
 
-  constructor(private dataService: Service) {
+  constructor(private dataService: Service, public generateComponent: GenerateComponent) {
   }
 
   ngOnInit() {
+    this.generateComponent.ngOnInit();
+    this.generateComponent.generateOutputHtmlCode();
     this.dataService.getHtmlValue().subscribe(observedData => this.htmlCode = observedData);
   }
 

--- a/src/app/service/service.ts
+++ b/src/app/service/service.ts
@@ -9,14 +9,26 @@ export class Service{
   private htmlCodeToPreview = new BehaviorSubject(STRING_TYPE.name.toString());
   private myBehaviorSubject = new BehaviorSubject<string>('');
   private numberOfSelectOptions = new BehaviorSubject<string[]>(['VALUE1', 'VALUE2', 'VALUE3']);
+  private index = new BehaviorSubject<number>(0);
+  private position = new BehaviorSubject<number>(0);
 
 
   currentData = this.dataToPass.asObservable();
   currentHtmlCode = this.htmlCodeToPreview.asObservable();
   currentNumberOfSelectOptions = this.numberOfSelectOptions.asObservable();
+  currentIndex = this.index.asObservable();
+  currentPosition = this.position.asObservable();
 
   changeCurrentData(m: Map<string, ComponentRef<any>>) {
     this.dataToPass.next(m)
+  }
+
+  changeIndex(n: number){
+    this.index.next(n);
+  }
+
+  changePosition(n: number){
+    this.position.next(n);
   }
 
   checkHtmlCodeChange(s: string) {

--- a/src/app/service/service.ts
+++ b/src/app/service/service.ts
@@ -11,6 +11,7 @@ export class Service{
   private numberOfSelectOptions = new BehaviorSubject<string[]>(['VALUE1', 'VALUE2', 'VALUE3']);
   private index = new BehaviorSubject<number>(0);
   private position = new BehaviorSubject<number>(0);
+  private dialogState = new BehaviorSubject<boolean>(false);
 
 
   currentData = this.dataToPass.asObservable();
@@ -18,9 +19,14 @@ export class Service{
   currentNumberOfSelectOptions = this.numberOfSelectOptions.asObservable();
   currentIndex = this.index.asObservable();
   currentPosition = this.position.asObservable();
+  currentDialogState = this.dialogState.asObservable();
 
   changeCurrentData(m: Map<string, ComponentRef<any>>) {
     this.dataToPass.next(m)
+  }
+
+  changeDialogState(ds: boolean) {
+    this.dialogState.next(ds);
   }
 
   changeIndex(n: number){
@@ -29,18 +35,6 @@ export class Service{
 
   changePosition(n: number){
     this.position.next(n);
-  }
-
-  checkHtmlCodeChange(s: string) {
-    this.htmlCodeToPreview.getValue();
-  }
-
-  setNumberOfSelectOption(num: string[]) {
-    this.numberOfSelectOptions.next(num);
-  }
-
-  getNumberOfSelectOption() {
-    return this.numberOfSelectOptions;
   }
 
   setHtmlValue(value: string) {


### PR DESCRIPTION
[PHR-13269](https://pkbdev.atlassian.net/browse/PHR-13269)


From the ticket: (elements with strike-through will be implemented in a follow up (PHR-13284)
- After using the “Clear Editor” button, the move up button removes the element. The element is only removed on the “Editor” page and not on the “Generated” tab. After using the “Clear Editor” button, move up should work as before using it.

- ~~Remove the Generate tab, as the users will not use that. Leave it for development purposes as it is easier to check if the HTML code generated is correct.~~

- ~~There is a copy HTML button, that copies the HTML code. That button is on the Preview window.~~

- ~~Configure the Generated tab in a way that it is visible on the localhost but not on the deployed version.~~

- “Back to top” element can be removed (currently it cannot be removed)

- HTML is not rendered correctly e.g. if the user goes directly to Preview tab from the Editor. User can see the correctly rendered HTML without going to the Generated tab beforehand.

- The correct order of the elements are visible on the Generated and Preview tab. Move up and move down button has only an effect on the Editor tab.

- After the LABELs there is no added space. Currently, it is visible on the Generated tab, that after the LABELs, there are 4-5 not necessary spaces.

- HTML tags rendered out nicely that it is readable. Currently, e.g. the closing tags are put into a next line, which makes it hard to read the HTML code if everything is correct.

- The name and the value attributes should be the same.

- Nice to have: check and implement drag and drop feature. As care plans can be long, it is hard to move up and down elements by buttons. If it is feasible, create a new ticket addressing that.

[PHR-13269]: https://pkbdev.atlassian.net/browse/PHR-13269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ